### PR TITLE
fix: meta tags for twitter and facebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .nuxt
 package-lock.json
+dist

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,29 +25,30 @@ export default {
         content: "Leniolabs_ LLC",
       },
 
-      { name: "og:type", content: "website" },
-      { name: "og:url", content: "https://tokens.layoutit.com" },
-      { name: "og:title", content: "Design Tokens Generator" },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://tokens.layoutit.com" },
+      { property: "og:title", content: "Design Tokens Generator" },
       {
-        name: "og:description",
+        property: "og:description",
         content:
           "Quickly create Design System tokens and get JSON, CSS and SASS code. Use our Design Tokens generator to quickstart your next project!",
       },
       {
-        name: "og:image",
+        property: "og:image",
         content: "https://tokens.layoutit.com/meta-image.png",
       },
 
-      { name: "twitter:card", content: "summary_large_image" },
-      { name: "twitter:url", content: "https://tokens.layoutit.com" },
-      { name: "twitter:title", content: "Design Tokens Generator" },
+      { property: "twitter:card", content: "summary_large_image" },
+      { property: "twitter:url", content: "https://tokens.layoutit.com" },
+      { property: "twitter:title", content: "Design Tokens Generator" },
       {
-        name: "twitter:description",
+        property: "twitter:description",
         content:
           "Quickly create Design System tokens and get JSON, CSS and SASS code. Use our Design Tokens generator to quickstart your next project!",
       },
-      { name: "twitter:image", content: "https://tokens.layoutit.com/meta-image.png" },
-      { name: "twitter:creator", content: "Leniolabs_ LLC" },
+      { property: "twitter:image", content: "https://tokens.layoutit.com/meta-image.png" },
+
+      { property: "twitter:creator", content: "Leniolabs_ LLC" },
     ],
     link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
   },


### PR DESCRIPTION
Changed key names for meta tags in order to work with Twitter and Facebook. Although this would work we still need to generate a robot.txt file to comply with the crawler. In the next image, we can see that they always look for this file before scanning the meta tags. It should be included. 

![image](https://user-images.githubusercontent.com/41266443/215168995-e8ead469-9e5f-4e6f-b82b-80ca20545a97.png)

Here's an image with the tags working
![image](https://user-images.githubusercontent.com/41266443/215169636-0778b413-9af2-4e29-a677-1e656a5c7fd9.png)

